### PR TITLE
This fixes set-exit-status when using `./...`

### DIFF
--- a/main.go
+++ b/main.go
@@ -275,6 +275,9 @@ func main() {
 				log.Fatalf("Failed to find unformatted files %s: %+v\n", originPath, err)
 			}
 			fmt.Printf("%s\n", unformattedFiles.String())
+			if *setExitStatus && unformattedFiles != nil {
+				os.Exit(1)
+			}
 			return
 		}
 		err := reviser.NewSourceDir(originProjectName, originPath, *isRecursive, excludes).Fix(options...)


### PR DESCRIPTION
https://github.com/incu6us/goimports-reviser/issues/93